### PR TITLE
Add X-KWin-Exclusive-Category to fix missing option in systems

### DIFF
--- a/kinetic_maximize/metadata.json
+++ b/kinetic_maximize/metadata.json
@@ -134,6 +134,7 @@
         "Name[zh_TW]": "最大化 (Kinetic)"
     },
     "X-KDE-Ordering": 60,
+    "X-KWin-Exclusive-Category": "maximize",
     "X-KWin-Video-Url": "https://files.kde.org/plasma/kwin/effect-videos/maximize.ogv",
     "X-Plasma-API": "javascript"
 }


### PR DESCRIPTION
I added the "X-KWin-Exclusive-Category" field to the metadata so the animation appears in the Window Maximize section under System Settings-Animations